### PR TITLE
Replaced atoi() with strtol() for better error handling.

### DIFF
--- a/canhazaxs.c
+++ b/canhazaxs.c
@@ -183,12 +183,13 @@ obtain_user_info(const char *user, const char *groups)
     /* append any extra groups */
     if (groups) {
         char *grnam = strtok(groups, ",");
+        char *endptr;
 
         while (grnam) {
             struct group *pg = getgrnam(grnam);
             if (!pg)
-                pg = getgrgid(atoi(grnam));
-            if (!pg) {
+                pg = getgrgid((int)strtol(grnam, &endptr, 10));
+            if (!pg || grnam == endptr) {
                 fprintf(stderr, "[!] Unknown group: %s\n", grnam);
             }
             else if (!in_group(pg->gr_gid))


### PR DESCRIPTION
If atoi() fails to convert, '0' is returned which matches the root user affecting the search group pool.

Consider adding range checks for strtol() return.

--{ Output sample:

```
shell@android:/data/local/tmp $ ./charm -g foo                                 
[*] uid=2000(shell), groups=1003(graphics),1004(input),1007(log),1009(mount),1011(adb),1015(sdcard_rw),3001(net_bt_admin),3002(net_bt),3003(inet),3006(net_bw_stats),2000(shell),0(root)
[*] Found 0 entries that are set-uid executable
[*] Found 0 entries that are set-gid executable
[*] Found 0 entries that are writable
shell@android:/data/local/tmp $
shell@android:/data/local/tmp $
shell@android:/data/local/tmp $ ./charm_patch -g foo                           
[!] Unknown group: foo
[*] uid=2000(shell), groups=1003(graphics),1004(input),1007(log),1009(mount),1011(adb),1015(sdcard_rw),3001(net_bt_admin),3002(net_bt),3003(inet),3006(net_bw_stats),2000(shell)
[*] Found 0 entries that are set-uid executable
[*] Found 0 entries that are set-gid executable
[*] Found 0 entries that are writable
```
